### PR TITLE
removing build errors

### DIFF
--- a/MSAL/src/public/MSAL.h
+++ b/MSAL/src/public/MSAL.h
@@ -76,6 +76,4 @@ FOUNDATION_EXPORT const unsigned char MSAL__Framework_VersionString[];
 #import <MSAL/MSALWebviewParameters.h>
 #import <MSAL/MSALSerializedADALCacheProvider.h>
 #import <MSAL/MSALWebviewParameters.h>
-#if TARGET_OS_IPHONE
-#import <MSAL/MSALLegacySharedAccountsProvider.h>
-#endif
+


### PR DESCRIPTION
Previously MSALLegacySharedAccountsProvider was exposed for us to use in our app, in the update this file does not exist and causes build errors.  Since we do not use it, i just removed the reference to it.  No issues in the codebase should result because of this.